### PR TITLE
feat: follow the current virtual desktop when showing an app

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ The effective log level is resolved with the following priority (highest first):
 - `hide_decorations`: optional boolean; hide the `KWin` title bar/border while plasma-drop manages the window
 - `hide_behavior`: optional `offscreen` (default) or `minimize`; determines whether hiding parks the window outside the screens or uses `KWin`'s minimized state
 - `hide_on_focus_lost`: optional boolean; hide the managed app when another window becomes active. Defaults to `false`.
+- `follow_current_desktop`: optional boolean; when the app is shown, move its window onto the virtual desktop you are currently viewing. Defaults to `false`.
 
 ## Matching Behavior
 
@@ -85,6 +86,24 @@ filename = "/usr/bin/kate"
 hide_behavior = "minimize"
 hide_on_focus_lost = true
 ```
+
+## Desktops
+
+By default a managed window stays on whatever virtual desktop it was opened on, so triggering the
+hotkey from another desktop reveals the window where it already lives. Set
+`follow_current_desktop = true` to move the window onto the desktop you are currently viewing each
+time it is shown, so the dropdown always appears in front of you:
+
+```toml
+[[app]]
+name = "terminal"
+hotkey = "super+grave"
+filename = "/usr/bin/kitty"
+follow_current_desktop = true
+```
+
+Only the virtual desktop assignment changes, and only at show time; placement, hiding, and animation
+still apply as configured. Defaults to `false`.
 
 ## Placement
 

--- a/resources/example-config.toml
+++ b/resources/example-config.toml
@@ -11,6 +11,8 @@ hide_decorations = true
 hide_behavior = "minimize"
 # Hide when another window becomes active, like a drop-down terminal.
 hide_on_focus_lost = true
+# Move the window onto the desktop you are currently viewing when shown (default: false).
+follow_current_desktop = true
 
 [app.placement]
 width = "50%"

--- a/resources/plasma-drop.kwin.js
+++ b/resources/plasma-drop.kwin.js
@@ -182,6 +182,14 @@ cmds["BRING_WINDOW_TO_FOREGROUND"] = (params) => {
     kwin.setActiveWindow(window);
     return {};
 };
+cmds["MOVE_WINDOW_TO_CURRENT_DESKTOP"] = (params) => {
+    const window = kwin.getWindowByInternalIdRequired(params.internalId);
+    const currentDesktop = workspace.currentDesktop;
+    if (currentDesktop) {
+        window.desktops = [currentDesktop];
+    }
+    return {};
+};
 cmds["REGISTER_HOT_KEY"] = (params) => {
     registerShortcut(params.name, params.title, params.sequence, () => {
         callDBus(

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,7 @@ pub struct AppConfig {
     pub hide_decorations: bool,
     pub hide_behavior: HideBehavior,
     pub hide_on_focus_lost: bool,
+    pub follow_current_desktop: bool,
     pub placement: PlacementConfig,
     pub animation: AnimationConfig,
 }
@@ -113,6 +114,7 @@ struct RawAppConfig {
     hide_decorations: Option<bool>,
     hide_behavior: Option<String>,
     hide_on_focus_lost: Option<bool>,
+    follow_current_desktop: Option<bool>,
     placement: Option<RawPlacementConfig>,
     animation: Option<RawAnimationConfig>,
 }
@@ -237,6 +239,7 @@ impl Config {
                 hide_decorations: app.hide_decorations.unwrap_or(false),
                 hide_behavior,
                 hide_on_focus_lost: app.hide_on_focus_lost.unwrap_or(false),
+                follow_current_desktop: app.follow_current_desktop.unwrap_or(false),
                 placement,
                 animation,
             });
@@ -529,6 +532,7 @@ mod tests {
             hide_decorations: None,
             hide_behavior: None,
             hide_on_focus_lost: None,
+            follow_current_desktop: None,
             placement: None,
             animation: None,
         }
@@ -593,6 +597,7 @@ mod tests {
         assert!(!config.apps[0].hide_decorations);
         assert_eq!(config.apps[0].hide_behavior, HideBehavior::Offscreen);
         assert!(!config.apps[0].hide_on_focus_lost);
+        assert!(!config.apps[0].follow_current_desktop);
     }
 
     #[test]
@@ -602,6 +607,15 @@ mod tests {
 
         let config = Config::from_raw(make_raw(vec![raw])).unwrap();
         assert!(config.apps[0].hide_decorations);
+    }
+
+    #[test]
+    fn accepts_follow_current_desktop_option() {
+        let mut raw = app("terminal", "ctrl+grave");
+        raw.follow_current_desktop = Some(true);
+
+        let config = Config::from_raw(make_raw(vec![raw])).unwrap();
+        assert!(config.apps[0].follow_current_desktop);
     }
 
     #[test]

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -178,6 +178,11 @@ impl ToggleService {
                 .minimize_window(&window.internal_id, false)
                 .await?;
         }
+        if config.follow_current_desktop {
+            self.kwin
+                .move_window_to_current_desktop(&window.internal_id)
+                .await?;
+        }
         if config.hide_decorations {
             self.hide_window_decorations(app_name, &window).await?;
         }
@@ -722,6 +727,14 @@ mod tests {
                 .push(format!("foreground:{internal_id}"));
             Ok(())
         }
+
+        async fn move_window_to_current_desktop(&self, internal_id: &str) -> Result<()> {
+            self.calls
+                .lock()
+                .await
+                .push(format!("desktop:{internal_id}"));
+            Ok(())
+        }
     }
 
     fn app(name: &str, hotkey: &str, filename: &str) -> AppConfig {
@@ -737,6 +750,7 @@ mod tests {
             hide_decorations: false,
             hide_behavior: HideBehavior::Offscreen,
             hide_on_focus_lost: false,
+            follow_current_desktop: false,
             placement: PlacementConfig::default(),
             animation: AnimationConfig::default(),
         }
@@ -874,6 +888,34 @@ mod tests {
         assert_eq!(
             calls,
             vec![
+                "move:{abc}:0:0:1920:1080".to_string(),
+                "resize:{abc}:0:0:1920:1080".to_string(),
+                "foreground:{abc}".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn toggle_on_moves_to_current_desktop_when_following() {
+        let mut app = app("dolphin", "super+f9", "dolphin");
+        app.follow_current_desktop = true;
+        let managed = managed_app(app, "{abc}", false);
+        let registry = Arc::new(Mutex::new(AppRegistry::new(vec![managed])));
+        let kwin = mock_kwin(Some(window(
+            "{abc}",
+            "dolphin",
+            "Dolphin",
+            geometry(10, 20, 300, 400),
+        )));
+        let service = ToggleService::new(registry, kwin.clone(), vec![screen()]);
+
+        service.toggle_app("dolphin").await.unwrap();
+
+        let calls = kwin.calls.lock().await.clone();
+        assert_eq!(
+            calls,
+            vec![
+                "desktop:{abc}".to_string(),
                 "move:{abc}:0:0:1920:1080".to_string(),
                 "resize:{abc}:0:0:1920:1080".to_string(),
                 "foreground:{abc}".to_string()

--- a/src/wm/kwin/client.rs
+++ b/src/wm/kwin/client.rs
@@ -309,6 +309,15 @@ impl KWinClient {
         Ok(())
     }
 
+    pub async fn move_window_to_current_desktop(&self, internal_id: &str) -> Result<()> {
+        self.send_command::<Value>(
+            "MOVE_WINDOW_TO_CURRENT_DESKTOP",
+            json!({ "internalId": internal_id }),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub async fn support_information_text(&self) -> Result<String> {
         let response: SupportInformationResponse = self
             .send_command("GET_SUPPORT_INFORMATION", json!({}))
@@ -404,5 +413,9 @@ impl WindowManager for KWinClient {
 
     async fn bring_window_to_foreground(&self, internal_id: &str) -> Result<()> {
         Self::bring_window_to_foreground(self, internal_id).await
+    }
+
+    async fn move_window_to_current_desktop(&self, internal_id: &str) -> Result<()> {
+        Self::move_window_to_current_desktop(self, internal_id).await
     }
 }

--- a/src/wm/mod.rs
+++ b/src/wm/mod.rs
@@ -23,4 +23,5 @@ pub trait WindowManager: Send + Sync {
     async fn set_window_no_border(&self, internal_id: &str, no_border: bool) -> Result<()>;
     async fn minimize_window(&self, internal_id: &str, minimized: bool) -> Result<()>;
     async fn bring_window_to_foreground(&self, internal_id: &str) -> Result<()>;
+    async fn move_window_to_current_desktop(&self, internal_id: &str) -> Result<()>;
 }

--- a/src/wm/types.rs
+++ b/src/wm/types.rs
@@ -105,6 +105,7 @@ mod tests {
             hide_decorations: false,
             hide_behavior: HideBehavior::Offscreen,
             hide_on_focus_lost: false,
+            follow_current_desktop: false,
             placement: PlacementConfig::default(),
             animation: AnimationConfig::default(),
         }


### PR DESCRIPTION
## Summary

Adds an opt-in per-app `follow_current_desktop` option. When enabled, the managed
window is moved onto the virtual desktop currently in view each time the app is
shown, so the dropdown appears on the desktop you are on instead of staying on the
one it was opened on.

Before this, a managed window stayed on whatever virtual desktop it was opened on,
so triggering the hotkey from another desktop revealed nothing on the current one.

## Behaviour

- New per-app boolean `follow_current_desktop`, default `false` — existing configs
  and behaviour are unchanged.
- When `true`, on show the window's desktop is set to `workspace.currentDesktop`
  before it is positioned and activated. Placement, hiding and animation are
  unaffected.

## Implementation

- KWin script: new `MOVE_WINDOW_TO_CURRENT_DESKTOP` command
  (`window.desktops = [workspace.currentDesktop]`).
- `WindowManager` trait + `KWinClient` method to send it.
- `ToggleService::show_app` invokes it only when the option is set.
- Config parsing + `AppConfig` field, defaulting to `false`.

## Tests / validation

- `make check` (fmt, clippy `-D warnings`, test, doc) passes.
- MSRV 1.88: `cargo build --locked --all-targets` and `cargo test --locked` pass.
- Added tests for config parsing (default + opt-in) and the show-path behaviour;
  existing sequence tests confirm no change when the option is off.
- Manually verified on Plasma 6 Wayland (dual monitor): with the flag on the app
  follows to the active desktop, with it off behaviour is unchanged.

## Docs

- `docs/configuration.md`: new `Desktops` section + Core Fields entry.
- `resources/example-config.toml`: documented example.

---

**Disclosure:** This change was co-authored by `claude-opus-4-8` (Claude Code) and human-verified.
